### PR TITLE
Update README.md with headers setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ const config = buildConfig({
 export default config;
 ```
 
+Add / extend the `express` configuration of your [Payload config](https://payloadcms.com/docs/configuration/overview), and set up the required `X-reCAPTHCA-V3` key in the `Access-Control-Allow-Headers` in the [postMiddleware](https://payloadcms.com/docs/configuration/express#custom-middleware) to avoid CORS errors:
+```ts
+
+const config = buildConfig({
+	// ... rest of your config (including the recaptcha plugin setup)
+	express: {
+	    postMiddleware: [
+	        (_req, res, next) => {
+	            const existingHeaders = res.getHeader("Access-Control-Allow-Headers");
+	            res.header(
+	                "Access-Control-Allow-Headers",
+	                existingHeaders + ", X-reCAPTCHA-V3"
+	            );
+	            next();
+	        },
+	    ],
+    },
+});
+
+```
+
 ### Plugin Options
 
 -   `secret`: string


### PR DESCRIPTION
I was getting the following CORS error:

```
Access to fetch at 'http://localhost:1337/api/comments' from origin 'http://localhost:3000' has been blocked by CORS policy: Request header field x-recaptcha-v3 is not allowed by Access-Control-Allow-Headers in preflight response.
```

I made changes in the documentation to include the required part in the payload config.